### PR TITLE
flash/nor/stm32h7x: fix flash write enable bug.

### DIFF
--- a/src/flash/nor/stm32h7x.c
+++ b/src/flash/nor/stm32h7x.c
@@ -668,6 +668,10 @@ static int stm32x_write(struct flash_bank *bank, const uint8_t *buffer,
 
 	/* multiple words (32-bytes) to be programmed in block */
 	if (blocks_remaining) {
+		retval = target_write_u32(target, stm32x_get_flash_reg(bank, FLASH_CR), FLASH_PG | FLASH_PSIZE_64);
+		if (retval != ERROR_OK)
+			goto flash_lock;
+
 		retval = stm32x_write_block(bank, buffer, offset, blocks_remaining);
 		if (retval != ERROR_OK) {
 			if (retval == ERROR_TARGET_RESOURCE_NOT_AVAILABLE) {


### PR DESCRIPTION
The bank x internal buffer control bit (PGx) needs to be set to enable
write operations before flashing an H7x part. The stm32x_write function
does this in its "standard programming" fallback loop and a branch for
handling remaining bytes, but never sets PGx prior to calling
stm32x_write_block. For some reason, the existing code still succeeds on
rev Y silicon, but fails on rev V parts.

This commit sets the PGx bit prior to calling stm32x_write_block.